### PR TITLE
Countrymask updates

### DIFF
--- a/acrg/countrymask.py
+++ b/acrg/countrymask.py
@@ -508,7 +508,7 @@ def create_country_mask(domain,lat=None,lon=None,reset_index=True,ocean_label=Tr
 
 def create_country_mask_eez(domain,include_land_territories=True,
                             include_ocean_territories=True,reset_index=True,fill_gaps=True,
-                            fp_directory=fp_directory,
+                            fp_directory=fp_directory,lat_lon_mask=False,sub_lats=None,sub_lons=None,
                             output_path=None,save=False):
     """
     Creates a mask for all countries within the domain.
@@ -536,6 +536,12 @@ def create_country_mask_eez(domain,include_land_territories=True,
         fp_directory (str, optional) :
             Base footprint directory to use to extract domain values. Uses footprint directory on data path
             by default and expects sub-directories of domain name.
+        lat_lon_mask (bool):
+            If True, masks all cells outside sub_lats and sub_lons (gives them values of np.nan).
+        sub_lats (list or array):
+            Either a list of [min_lat,max_lat] or a numpy array of lats. Any cells beyond these limits are masked.
+        sub_lons (list or array):
+            Either a list of [min_lon,max_lon] or a numpy array of lons. Any cells beyond these limits are masked.
          out_path (str) (optional):
             Path and name to save mask to. If None, does not save dataset.
     Returns:
@@ -667,6 +673,15 @@ def create_country_mask_eez(domain,include_land_territories=True,
 
                         all_grid[i,j] = stats.mode(surrounding)[0][0]
     
+    if lat_lon_mask == True:
+        print(f'Masking all values beyond lats: {sub_lats[0]}:{sub_lats[-1]} and lons: {sub_lons[0]}:{sub_lons[-1]}')
+        
+        lats_outer = np.where((lats < sub_lats[0]) | (lats >= sub_lats[-1]))[0]
+        lons_outer = np.where((lons < sub_lons[0]) | (lons >= sub_lons[-1]))[0]
+        
+        all_grid[lats_outer,:] = np.nan
+        all_grid[:,lons_outer] = np.nan
+        
     # create output dataset
     if reset_index == True:
         ncountries = np.arange(len(country_names)+1)

--- a/acrg/countrymask.py
+++ b/acrg/countrymask.py
@@ -508,8 +508,8 @@ def create_country_mask(domain,lat=None,lon=None,reset_index=True,ocean_label=Tr
 def mask_fill_gaps(mask_array):
     
     #TODO: create a test for fill_gaps
-    print('\nFilling in gaps between masks\nby checking for grid cells where surrounding cells are indentical.')
-    print('WARNING: This is experimental, when using this mask to estimate country emissions from countries'+
+    print('\nFilling in gaps between masksby checking for grid cells where surrounding cells are indentical.')
+    print('WARNING: This is experimental, when using this mask to estimate country emissions from countries '+
           'with complex coastlines you should manually check the mask before use.')
     print('WARNING: This does not work for any gaps that are on the edge of the domain.')
         
@@ -536,12 +536,12 @@ def mask_fill_gaps(mask_array):
                     
     return mask_array
 
-def create_country_mask_eez(domain,include_land_territories=True,
+def create_country_mask_eez(domain,lat=None,lon=None,include_land_territories=True,
                             include_ocean_territories=True,reset_index=True,fill_gaps=True,
                             fp_directory=fp_directory,lat_lon_mask=False,sub_lats=None,sub_lons=None,
                             output_path=None,save=False):
     """
-    Creates a mask for all countries within the domain.
+    Creates a mask for all countries within the domain (or lat/lon bounds).
     Uses Natural Earth 10m land datasets and Admin_0_map_units datasets
     for specifiying country and ocean boundaries.
     Option to include EEZ (Exclusive Economic Zones e.g. marine 
@@ -551,7 +551,12 @@ def create_country_mask_eez(domain,include_land_territories=True,
     
     Args:
         domain (str):
-            The domain the mask should cover, e.g. 'EUROPE'.
+            The domain the mask should cover, e.g. 'EUROPE'. If lat and lon are not specified,
+            will use the domain to extract the latitudes and longitudes.
+        lat (numpy array) (optional):
+            Latitudes to create mask over. If not specified, will extract lats from a domain.
+        lon (numpy array) (optional):
+            Longitudes to create mask over. If not specified, will extract lons from a domain.
         include_land_territories (bool):
             If True, include land territories for all countries in the 
             country mask.
@@ -568,9 +573,9 @@ def create_country_mask_eez(domain,include_land_territories=True,
             by default and expects sub-directories of domain name.
         lat_lon_mask (bool):
             If True, masks all cells outside sub_lats and sub_lons (gives them values of np.nan).
-        sub_lats (list or array):
+        sub_lats (list or array) (optional):
             Either a list of [min_lat,max_lat] or a numpy array of lats. Any cells beyond these limits are masked.
-        sub_lons (list or array):
+        sub_lons (list or array) (optional):
             Either a list of [min_lon,max_lon] or a numpy array of lons. Any cells beyond these limits are masked.
          out_path (str) (optional):
             Path and name to save mask to. If None, does not save dataset.
@@ -582,8 +587,16 @@ def create_country_mask_eez(domain,include_land_territories=True,
     print("If you are having issues with downloading the required files from natural earth:")
     print("Try installing cartopy version 0.20.0, this may fix the issue.")
    
-    # extract lats and lons from fp file
-    lats,lons,heights = domain_volume(domain,fp_directory=fp_directory)
+    if lat is not None:
+        lat_range = [lat[0],lat[-1]]
+        lon_range = [lon[0],lon[-1]]
+        print(f'\nCreating mask between lats: {lat_range} and lons: {lon_range}.')
+        lats = lat
+        lons = lon
+    else:
+        print(f'\nExtracting lats and lons from domain: {domain}.')
+        # extract lats and lons from fp file
+        lats,lons,heights = domain_volume(domain,fp_directory=fp_directory)
 
     # load in land files
     shpfilename_land = shapereader.natural_earth('10m','cultural','admin_0_map_units')

--- a/tests/test_countrymask.py
+++ b/tests/test_countrymask.py
@@ -165,6 +165,7 @@ def test_fill_gaps(mask_with_gaps,mask_no_gaps,fp_directory):
     
     assert np.array_equal(filled_array,mask_no_gaps) == True
     
+@pytest.mark.skipif(not glob.glob(os.path.join(data_path,"LPDM/fp_NAME/")), reason="No access to files in data_path")
 def test_get_country(fp_directory):
     """
     Creates a countryfile and checks that name.get_country can 

--- a/tests/test_countrymask.py
+++ b/tests/test_countrymask.py
@@ -9,6 +9,7 @@ import pytest
 import os
 import glob
 import numpy as np
+from acrg.name.name import get_country
 
 from acrg import countrymask
 from acrg.config.paths import Paths
@@ -154,7 +155,6 @@ def test_country_match(country_codes,not_country_codes,fp_directory):
         
         assert len(country_code_match) == 0
         
-@pytest.mark.skipif(not glob.glob(os.path.join(data_path,"World_shape_databases")), reason="No access to files in data_path.")
 def test_fill_gaps(mask_with_gaps,mask_no_gaps,fp_directory):
     """
     Tests that mask_fill_gaps in correctly fills in all gaps in the mask 
@@ -165,4 +165,27 @@ def test_fill_gaps(mask_with_gaps,mask_no_gaps,fp_directory):
     
     assert np.array_equal(filled_array,mask_no_gaps) == True
     
+def test_get_country(fp_directory):
+    """
+    Creates a countryfile and checks that name.get_country can 
+    read this file and extract all required variables.
+    Then removes this file.
+    """
+    
+    output_path = os.path.join(acrg_path,'tests/files/LPDM/countries/country_EUROPE')
+    
+    c_mask = countrymask.create_country_mask_eez(domain='EUROPE',include_land_territories=True,
+                                                 include_ocean_territories=True,reset_index=True,
+                                                 fill_gaps=False,fp_directory=fp_directory,
+                                                 output_path=output_path,save=True)
+    
+    c_mask_extracted = get_country(domain='EUROPE',country_file=output_path+'.nc')
+    
+    assert c_mask_extracted
+    assert type(c_mask_extracted.country) == np.ndarray
+    assert type(c_mask_extracted.name) == np.ndarray
+    
+    if os.path.exists(output_path+'.nc'):
+        os.remove(output_path+'.nc')
+
 # Samoa lat and lon 13.7590° S, 172.1046° W

--- a/tests/test_countrymask.py
+++ b/tests/test_countrymask.py
@@ -26,7 +26,26 @@ def not_country_codes():
     country_codes = ['BRA','CHN','NZL']
     return country_codes
 
+@pytest.fixture(scope="module")
+def mask_with_gaps():
+    mask_with_gaps = np.array([[1,1,1,4,4,4],
+                               [1,0,1,2,2,2],
+                               [1,1,1,2,0,0],
+                               [3,3,3,2,2,2],
+                               [3,0,3,5,5,5],
+                               [3,3,0,5,6,6]])
+    return mask_with_gaps
 
+@pytest.fixture(scope="module")
+def mask_no_gaps():
+    mask_no_gaps = np.array([[1,1,1,4,4,4],
+                             [1,1,1,2,2,2],
+                             [1,1,1,2,2,0],
+                             [3,3,3,2,2,2],
+                             [3,3,3,5,5,5],
+                             [3,3,0,5,6,6]])
+    return mask_no_gaps
+    
 #%% Tests for domain_volume function
 
 def test_incorrect_domain():
@@ -81,6 +100,8 @@ def test_convert_lons_0360():
     assert all(lon_0360 >= 0) is True
     assert all(lon_0360 < 360) is True
 
+# Tests for create_country_mask_eez
+    
 @pytest.mark.skipif(not glob.glob(os.path.join(data_path,"World_shape_databases")), reason="No access to files in data_path")
 def test_country_match(country_codes,not_country_codes,fp_directory):
     """
@@ -132,5 +153,16 @@ def test_country_match(country_codes,not_country_codes,fp_directory):
         country_code_match = [not_c_code for c in ds_both['country_code'].values if not_c_code == c]
         
         assert len(country_code_match) == 0
+        
+@pytest.mark.skipif(not glob.glob(os.path.join(data_path,"World_shape_databases")), reason="No access to files in data_path.")
+def test_fill_gaps(mask_with_gaps,mask_no_gaps,fp_directory):
+    """
+    Tests that mask_fill_gaps in correctly fills in all gaps in the mask 
+    by searching for empty grid cells which are surrounded by identically filled grid cells.
+    """
+    
+    filled_array = countrymask.mask_fill_gaps(mask_with_gaps)
+    
+    assert np.array_equal(filled_array,mask_no_gaps) == True
     
 # Samoa lat and lon 13.7590° S, 172.1046° W


### PR DESCRIPTION
### Description 

I've updated create_country_mask_eez to align as much as possilble with the original create_countrymask function. 

#### Changes:

1. Added option 'reset_index': 
If True, it starts indexing county values from 0. If False, it uses the Natural_Earth country index values to fill in the map. I couldn't get this to match with with the country values in files created by create_countrymask as the two functions use different methods for retrieving the country shapefiles. These two methods order and index the countries differently, so are not equivalent. The new function also indexes countries by ISO 3166/alpha-3 codes, which should allow for easy comparison instead. 

2. Added option 'lat_lon_mask':
You can specifify lat lon ranges or arrays, to mask the domain further.

3. Fixes and a test for fill_gaps.
This is a basic test which doesn't use a real-world example, so may need expanding later.

Resolves issue #117 (and potentially issue #32)

#### Type of Change:
[ ] Bug fix
[X] New feature
[ ] Code-breaking change

#### Checklist:
[ ] Code documentation has been updated if needed
[X] If new tests are needed, they have been added
[X] All tests pass
[X] No merge conflicts
[] /CHANGELOG.md has been updated if change is significant