### PR TITLE
Joe test fix

### DIFF
--- a/tests/test_obs.py
+++ b/tests/test_obs.py
@@ -217,9 +217,9 @@ def test_obs_process_crds():
     
     # Check a particular value (note that time stamp is 10 minutes before analysis time,
     # because in GCWerks files, times are at the beginning of the sampling period)
-    assert np.allclose(ds.sel(time = slice("2014-01-30 14:00:00", "2014-01-30 14:01:00")).ch4.values,
+    assert np.allclose(ds.sel(time = slice("2014-01-30 14:00:00", "2014-01-30 14:00:00")).ch4.values,
                        np.array(1953.88))
-    assert np.allclose(ds.sel(time = slice("2014-01-30 14:00:00", "2014-01-30 14:01:00"))["ch4_variability"].values,
+    assert np.allclose(ds.sel(time = slice("2014-01-30 14:00:00", "2014-01-30 14:00:00"))["ch4_variability"].values,
                        np.array(0.398))
 
     # clean up


### PR DESCRIPTION
After changing the obs processing script so that the processed .nc files are timestamped at the start of the averaging period (rather than the middle), test_obs.py needed updating accordingly.

The directory tests/files/LPDM/countries is needed for test_countrymask.py::test_get_country, but because it is initially empty it doesn't get committed. I've added a .gitkeep file in there to avoid this. It's possible I've misunderstood things if this has been working fine for everyone else - feel free to reject if this is the case!