### PR TITLE
Add lifetime for HCFO-1233zde

### DIFF
--- a/data/species_info.json
+++ b/data/species_info.json
@@ -427,10 +427,12 @@
     },
     "HCFO-1233zde": {"alt": ["HCFO1233zde", "HCFO-1233ZDE", "HCFO1233ZDE","hcfo1233zde","hcfo-1233zde","HFO1233zde", "HFO-1233ZDE", "HFO1233ZDE","hfo1233zde","hfo-1233zde"],
         "group": "HFOs", 
-        "long_name": "HFO-1233zd(E)", 
+        "long_name": "HCFO-1233zd(E)", 
         "mol_mass": "130.49", 
-        "print_string": "HFO-1233ZDE", 
-        "units": "ppt"
+        "print_string": "HCFO-1233ZDE", 
+        "units": "ppt",
+        "lifetime": ["125.6D", "85.7D", "49.8D", "27.5D", "17.1D", "12.8D","13.2D", "16.5D", "27.8D","52.5D","108.9D","147.6D"],
+        "lifetime_reference":"2018 ozone assessment with monthly profile derived from HFO-1234yf from Henne et al., 2012"
     },
     "Isoflurane": {"alt": [],
         "group": "Minor", 


### PR DESCRIPTION
Adds lifetime info for HCFO-1233zde to species_info.json. Monthly lifetimes are based on the temporal profile of HFO-1234yf lifetime from Henne et al., 2012, adjusted for HCFO-1233zde using the relative annual values from the 2018 ozone assessment.