### PR TITLE
Add `openghg_defs` from our conda channel to environment files

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,6 @@
 name: acrg
 channels:
   - conda-forge
-  - openghg
 dependencies:
   - python=3.10
   - pymc3=3.9
@@ -25,4 +24,5 @@ dependencies:
   - pytest=7.2
   - pyfakefs=5.1
   - cachetools=5.3
-  - openghg_defs=0.0.2
+  - pip:
+    - openghg_defs @ git+https://github.com/openghg/openghg_defs

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,7 @@
 name: acrg
 channels:
   - conda-forge
+  - openghg
 dependencies:
   - python=3.10
   - pymc3=3.9
@@ -24,5 +25,4 @@ dependencies:
   - pytest=7.2
   - pyfakefs=5.1
   - cachetools=5.3
-  - pip:
-    - openghg_defs @ git+https://github.com/openghg/supplementary_data
+  - openghg_defs=0.0.2

--- a/environment_variable.yml
+++ b/environment_variable.yml
@@ -2,6 +2,7 @@
 name: acrg_var
 channels:
   - conda-forge
+  - openghg
 dependencies:
   - python=3.10
   - pymc3
@@ -25,3 +26,4 @@ dependencies:
   - pytest
   - pyfakefs
   - cachetools
+  - openghg_defs

--- a/environment_variable.yml
+++ b/environment_variable.yml
@@ -2,7 +2,6 @@
 name: acrg_var
 channels:
   - conda-forge
-  - openghg
 dependencies:
   - python=3.10
   - pymc3
@@ -26,4 +25,5 @@ dependencies:
   - pytest
   - pyfakefs
   - cachetools
-  - openghg_defs
+  - pip:
+    - openghg_defs @ git+https://github.com/openghg/openghg_defs


### PR DESCRIPTION
This updates the environment files to use `openghg_defs` from our conda channel.

Closes #162 