### PR TITLE
Changes to min_model_error and option for pollution from obs

### DIFF
--- a/acrg/paris_formatting/make_paris_outputs.py
+++ b/acrg/paris_formatting/make_paris_outputs.py
@@ -43,9 +43,9 @@ def get_netcdf_files(directory: Union[str, Path], filename_search: Optional[str]
 def get_inversion_outputs_with_samples(
     species: str,
     output_file_path: str,
-    min_model_error: float = 0.1,
     ndraw: int = 1000,
     n_files: Optional[int] = None,
+    pol_from_obs: bool = False,
 ) -> list[InversionOutput]:
     """Create a list of InversionOutputs given a path to RHIME inversion outputs."""
     files = get_netcdf_files(output_file_path, filename_search=species.upper())
@@ -54,7 +54,7 @@ def get_inversion_outputs_with_samples(
         files = files[:n_files]
 
     inv_outs = [
-        InversionOutput.from_rhime(xr.open_dataset(file), min_model_error, ndraw=ndraw) for file in files
+        InversionOutput.from_rhime(xr.open_dataset(file), pol_from_obs=pol_from_obs, ndraw=ndraw) for file in files
     ]
 
     for inv_out in inv_outs:
@@ -191,12 +191,12 @@ def main(
     species: str,
     output_file_path: str,
     country_file_path: str,
-    min_model_error: float,
     avr_obs_period: str,
     n_files: Optional[int] = None,
     return_concentrations: bool = True,
     report_mf_mode: bool = False,
     report_em_mode: bool = True,
+    pol_from_obs: bool = False,
 ) -> tuple[xr.Dataset, Optional[xr.Dataset]]:
     """Create formatted PARIS emissions and concentrations datasets.
 
@@ -204,18 +204,18 @@ def main(
         species: species used in inversion
         output_file_path: path to directory containing RHIME outputs
         country_files_root: path to directory containing country files
-        min_model_error: the minimum model error used with the inversion
         avr_obs_period: the averaging period for measurements used in inversion
         n_files: number of output files to process. This is mainly to keep runs small for testing.
         return_concentrations: if False, only country and flux outputs are returned. (None is returned for concentrations.)
         report_mf_mode: if True, use mode for concentration prior/posterior predictives (i.e. for y and y BC)
         report_em_mode: if True, use mode for country and flux prior/posterior totals
+        pol_from_obs: if True, this means that pollution_events_from_obs=True was specified
 
     Returns:
         emissions dataset and concentrations dataset
     """
     inv_outs = get_inversion_outputs_with_samples(
-        species=species, output_file_path=output_file_path, min_model_error=min_model_error, n_files=n_files
+        species=species, output_file_path=output_file_path, n_files=n_files, pol_from_obs=pol_from_obs
     )
 
     # make country and flux output
@@ -311,7 +311,6 @@ if __name__ == "__main__":
         type=str,
         help="path to country file; e.g. '/group/acrg/chem/LPDM/countries/country_EUROPE.nc'",
     )
-    parser.add_argument("-m", "--min-model-error", type=float, help="min. model error used in inversion")
     parser.add_argument("-p", "--avr-obs-period", type=str, help="averaging period for measurements used in inversion")
     parser.add_argument("-o", "--output-path", type=str, help="path to dir to write formatted outputs")
     parser.add_argument("-t", "--output-tag", type=str, help="tag to add to output file names")
@@ -333,7 +332,13 @@ if __name__ == "__main__":
             action="store_true",
             default=False,
             help="if set, report mean for country and flux totals (by default, mode is reported).",
-        )
+    )
+    parser.add_argument(
+            "--pol-obs",
+            action="store_true",
+            default=False,
+            help="if set, this means that pollution_events_from_obs=True was specified",
+    )
 
 
     args = parser.parse_args()
@@ -342,12 +347,12 @@ if __name__ == "__main__":
         species=args.species,
         output_file_path=args.rhime_outputs_path,
         country_file_path=args.country_file_path,
-        min_model_error=args.min_model_error,
         avr_obs_period=args.avr_obs_period,
         n_files=args.n_files,
         return_concentrations=(not args.no_conc),
         report_mf_mode=args.mode,
         report_em_mode=(not args.em_mean),
+        pol_from_obs=args.pol_obs
     )
 
     if args.output_tag:

--- a/acrg/paris_formatting/process_rhime_output.py
+++ b/acrg/paris_formatting/process_rhime_output.py
@@ -142,7 +142,7 @@ class InversionOutput:
 
     @classmethod
     def from_rhime(
-        cls: type[InvOut], ds: xr.Dataset, min_model_error: float, ndraw: Optional[int] = None
+        cls: type[InvOut], ds: xr.Dataset, pol_from_obs: bool, ndraw: Optional[int] = None
     ) -> InvOut:
         """Make InversionOutput object from RHIME output dataset."""
         flux = ds.fluxapriori
@@ -168,7 +168,7 @@ class InversionOutput:
             model_kwargs["bcprior"] = None
             model_kwargs["bcprior_dims"] = None
 
-        model = get_rhime_model(ds_clean, min_model_error=min_model_error, use_bc=use_bc, **model_kwargs)  # type: ignore
+        model = get_rhime_model(ds_clean, use_bc=use_bc, pol_from_obs=pol_from_obs, **model_kwargs)  # type: ignore
 
         if ndraw is not None:
             trace = make_idata_from_rhime_outs(ds_clean, ndraw=ndraw)

--- a/acrg/paris_formatting/sampling.py
+++ b/acrg/paris_formatting/sampling.py
@@ -77,10 +77,9 @@ def parse_prior(name: str, prior_params: PriorArgs, **kwargs) -> TensorVariable:
 
 
 def get_sampling_kwargs_from_rhime_outs(
-    rhime_outs: xr.Dataset, min_model_error: Optional[float] = None
+    rhime_outs: xr.Dataset
 ) -> dict[str, Union[None, float, PriorArgs]]:
     """Make dict of arguments to use with `get_rhime_model` given a RHIME output file
-    and minimum model error.
 
     Convenience function for creating PARIS outputs based on RHIME/HBMCMC outputs.
     """
@@ -105,23 +104,23 @@ def get_sampling_kwargs_from_rhime_outs(
         bcprior = None
 
     result["bcprior"] = bcprior
+    result["min_model_error"] = rhime_outs.attrs["min_model_error"]
 
-    if min_model_error:
-        result["min_model_error"] = min_model_error
     return result
 
 
 def get_rhime_model(
     rhime_outs_ds: xr.Dataset,
+    min_model_error: float,
     xprior: PriorArgs,
     sigprior: PriorArgs,
     xprior_dims: Union[str, tuple[str, ...]],
     sigprior_dims: Union[str, tuple[str, ...]],
     bcprior_dims: Union[None, str, tuple[str, ...]] = None,
     bcprior: Optional[PriorArgs] = None,
-    min_model_error: float = 20.0,
     coord_dim: str = "nmeasure",
     use_bc: bool = True,
+    pol_from_obs: bool = False,
 ) -> pm.Model:
     """Make RHIME model wih model error given by multiplicative scaling of pollution events
     plus constant minimum value.
@@ -137,6 +136,7 @@ def get_rhime_model(
         min_model_error: constant minimum model error
         coord_dim: name of dimension used for coordinates of observations
         use_bc: if False, run without boundary conditions (e.g. if baseline subtracted from observations)
+        pol_from_obs: if True, this means that pollution_events_from_obs=True was specified
 
     Returns:
         PyMC model for RHIME model with given priors and minimum model error.
@@ -167,8 +167,16 @@ def get_rhime_model(
         else:
             mu = pt.dot(rhime_outs_ds.xsensitivity.values, x)
 
+        if pol_from_obs is True:
+            if use_bc is True:
+                pollution_event = np.abs(rhime_outs_ds.Yobs.values - pt.dot(rhime_outs_ds.bcsensitivity.values, bc))
+            else:
+                pollution_event = rhime_outs_ds.Yobs.values
+        else:
+            pollution_event = np.abs(pt.dot(rhime_outs_ds.xsensitivity.values, x))
+                
         mult_error = (
-            np.abs(pt.dot(rhime_outs_ds.xsensitivity.values, x))
+            pollution_event
             * sigma[
                 rhime_outs_ds.siteindicator.values.astype(int),
                 rhime_outs_ds.sigmafreqindex.values.astype(int),
@@ -176,7 +184,7 @@ def get_rhime_model(
         )
         epsilon = pm.Deterministic(
             "epsilon",
-            pt.sqrt(rhime_outs_ds.Yerror.values**2 + mult_error**2 + min_model_error**2),
+            pt.maximum(pt.sqrt(rhime_outs_ds.Yerror.values**2 + mult_error**2), min_model_error),
             dims=coord_dim,
         )
         pm.Normal("y", mu, epsilon, dims=coord_dim, observed=rhime_outs_ds.Yobs)


### PR DESCRIPTION
Update the post-processing code to reflect changes in openghg_inversions merged in the following PRs:
https://github.com/openghg/openghg_inversions/pull/111
https://github.com/openghg/openghg_inversions/pull/117

The code now reads min_model_error from the saved attribute in the outputs file. It is then applied as a minimum value (lower bound) as it was in the inversion. If the inversion was run with `pollution_events_from_obs = True`, you now use the `--pol-obs` option when running this post-processing code.

This addresses Issue #165 