### PR TITLE
Paris formatting model updates

### DIFF
--- a/acrg/paris_formatting/make_paris_outputs.py
+++ b/acrg/paris_formatting/make_paris_outputs.py
@@ -419,8 +419,8 @@ if __name__ == "__main__":
 
     if args.output_tag:
         tag = args.output_tag
-        emissions_output_path = output_path / f"{tag}_{args.species}_yearly.nc"
-        conc_output_path = output_path / f"{tag}_{args.species}_yearly_concentrations.nc"
+        emissions_output_path = output_path / f"{tag}.nc"
+        conc_output_path = output_path / f"{tag}_concentrations.nc"
     else:
         date, time = str(timestamp_now()).split(" ")
         tag = date + "_" + time.split(".")[0].replace(":", "")

--- a/acrg/paris_formatting/make_paris_outputs.py
+++ b/acrg/paris_formatting/make_paris_outputs.py
@@ -46,6 +46,7 @@ def get_inversion_outputs_with_samples(
     ndraw: int = 1000,
     n_files: Optional[int] = None,
     pol_from_obs: bool = False,
+    no_model_error: bool = False,
 ) -> list[InversionOutput]:
     """Create a list of InversionOutputs given a path to RHIME inversion outputs."""
     files = get_netcdf_files(output_file_path, filename_search=species.upper())
@@ -54,7 +55,9 @@ def get_inversion_outputs_with_samples(
         files = files[:n_files]
 
     inv_outs = [
-        InversionOutput.from_rhime(xr.open_dataset(file), pol_from_obs=pol_from_obs, ndraw=ndraw)
+        InversionOutput.from_rhime(
+            xr.open_dataset(file), pol_from_obs=pol_from_obs, no_model_error=no_model_error, ndraw=ndraw
+        )
         for file in files
     ]
 
@@ -235,6 +238,7 @@ def main(
     report_em_mode: bool = True,
     pol_from_obs: bool = False,
     no_model_error: bool = False,
+    ndraw: int = 10000,
 ) -> tuple[xr.Dataset, Optional[xr.Dataset]]:
     """Create formatted PARIS emissions and concentrations datasets.
 
@@ -258,6 +262,7 @@ def main(
         n_files=n_files,
         pol_from_obs=pol_from_obs,
         no_model_error=no_model_error,
+        ndraw=ndraw,
     )
 
     # make country and flux output
@@ -389,6 +394,7 @@ if __name__ == "__main__":
         default=False,
         help="if set, this means that no_model_error=True was specified",
     )
+    parser.add_argument("--ndraw", type=int, default=10000, help="number of prior/predictive samples to produce")
 
     args = parser.parse_args()
 
@@ -403,6 +409,7 @@ if __name__ == "__main__":
         report_em_mode=(not args.em_mean),
         pol_from_obs=args.pol_obs,
         no_model_error=args.no_model_error,
+        ndraw=args.ndraw,
     )
 
     output_path = Path(args.output_path)

--- a/acrg/paris_formatting/make_paris_outputs.py
+++ b/acrg/paris_formatting/make_paris_outputs.py
@@ -19,7 +19,7 @@ from attribute_parsers import (
     convert_time_to_unix_epoch,
 )
 from countries import Countries
-from array_ops import sparse_xr_dot 
+from array_ops import sparse_xr_dot
 from process_rhime_output import InversionOutput
 from stats import calculate_stats
 
@@ -54,7 +54,8 @@ def get_inversion_outputs_with_samples(
         files = files[:n_files]
 
     inv_outs = [
-        InversionOutput.from_rhime(xr.open_dataset(file), pol_from_obs=pol_from_obs, ndraw=ndraw) for file in files
+        InversionOutput.from_rhime(xr.open_dataset(file), pol_from_obs=pol_from_obs, ndraw=ndraw)
+        for file in files
     ]
 
     for inv_out in inv_outs:
@@ -93,22 +94,28 @@ def make_country_output(
     country_traces_merged = xr.concat(country_traces, dim="time")
 
     # apply `get_country_code` to each element of `country` coordinate
-    country_codes = list(map(partial(get_country_code, code=code), map(str, country_traces_merged.country.values)))
+    country_codes = list(
+        map(partial(get_country_code, code=code), map(str, country_traces_merged.country.values))
+    )
     country_traces_merged = country_traces_merged.assign_coords(country=country_codes)
 
     # add country regions
-    regions_dict = {'BELUX':'BEL-LUX',
-                'BENELUX':'BEL-LUX-NLD',
-                'CW_EU':'AUT-BEL-CHE-CZE-DEU-ESP-FRA-GBR-HRV-HUN-IRL-ITA-LUX-NLD-POL-PRT-SVK-SVN',
-                'EU_GRP2':'AUT-BEL-CHE-DEU-DNK-FRA-GBR-IRL-ITA-LUX-NLD',
-                'NW_EU':'BEL-DEU-DNK-FRA-GBR-IRL-LUX-NLD',
-                'NW_EU2':'BEL-DEU-FRA-GBR-IRL-LUX-NLD',
-                'NW_EU_CONTINENT':'BEL-DEU-FRA-LUX-NLD'}
+    regions_dict = {
+        "BELUX": "BEL-LUX",
+        "BENELUX": "BEL-LUX-NLD",
+        "CW_EU": "AUT-BEL-CHE-CZE-DEU-ESP-FRA-GBR-HRV-HUN-IRL-ITA-LUX-NLD-POL-PRT-SVK-SVN",
+        "EU_GRP2": "AUT-BEL-CHE-DEU-DNK-FRA-GBR-IRL-ITA-LUX-NLD",
+        "NW_EU": "BEL-DEU-DNK-FRA-GBR-IRL-LUX-NLD",
+        "NW_EU2": "BEL-DEU-FRA-GBR-IRL-LUX-NLD",
+        "NW_EU_CONTINENT": "BEL-DEU-FRA-LUX-NLD",
+    }
 
     region_traces = []
     for region, countries_str in regions_dict.items():
         countries = countries_str.split("-")
-        region_ds = country_traces_merged.sel(country=countries).sum("country").expand_dims({"country": [region]})
+        region_ds = (
+            country_traces_merged.sel(country=countries).sum("country").expand_dims({"country": [region]})
+        )
         region_traces.append(region_ds)
 
     region_traces_merged = xr.concat(region_traces, dim="country")
@@ -117,23 +124,26 @@ def make_country_output(
     all_traces_merged = xr.merge([country_traces_merged, region_traces_merged])
 
     country_output = xr.merge(
-        calculate_stats(all_traces_merged, "country", chunk_dim="country", chunk_size=1, report_mode=report_mode)
+        calculate_stats(
+            all_traces_merged, "country", chunk_dim="country", chunk_size=1, report_mode=report_mode
+        )
     )
-
-
-
 
     return country_output
 
 
 def make_flux_outputs(
-        inv_outs: list[InversionOutput], time_point: Literal["start", "midpoint"] = "midpoint", report_mode: bool = True,
+    inv_outs: list[InversionOutput],
+    time_point: Literal["start", "midpoint"] = "midpoint",
+    report_mode: bool = True,
 ) -> xr.Dataset:
     """Make flux output dataset"""
 
     # calculate stats on flux traces
     traces = [inv_out.get_trace_dataset(convert_nmeasure=False, var_names="x") for inv_out in inv_outs]
-    stats = [xr.merge(calculate_stats(trace, "flux", chunk_dim="nx", report_mode=report_mode)) for trace in traces]
+    stats = [
+        xr.merge(calculate_stats(trace, "flux", chunk_dim="nx", report_mode=report_mode)) for trace in traces
+    ]
 
     time_func = partial(get_time_point, time_point=time_point)
 
@@ -158,7 +168,13 @@ def make_concentration_outputs(inv_outs: list[InversionOutput], report_mode: boo
         if use_bc:
             var_names = ["mu_bc_posterior", "mu_bc_prior"]
             stats = calculate_stats(
-                preds, name="Y", chunk_dim="nmeasure", chunk_size=1, var_names=var_names, report_mode=report_mode, add_bc_suffix=True,
+                preds,
+                name="Y",
+                chunk_dim="nmeasure",
+                chunk_size=1,
+                var_names=var_names,
+                report_mode=report_mode,
+                add_bc_suffix=True,
             )
         else:
             stats = []
@@ -200,12 +216,13 @@ def rename_drop_dvs_for_template(ds: xr.Dataset, var_name: str) -> tuple[dict[st
 
     return rename_dict, vars_to_drop
 
+
 def shift_measurement_time_to_midpoint(ds: xr.Dataset, period: str = "4h") -> np.ndarray:
-    """Adjust `time` coordinate of concentrations to represent half averaging "period".
-    """
-    time_midpoint = ds['time'].astype('datetime64[ns]') + np.timedelta64(int(period[:-1]) , period[-1]) / 2
+    """Adjust `time` coordinate of concentrations to represent half averaging "period"."""
+    time_midpoint = ds["time"].astype("datetime64[ns]") + np.timedelta64(int(period[:-1]), period[-1]) / 2
 
     return time_midpoint
+
 
 def main(
     species: str,
@@ -217,6 +234,7 @@ def main(
     report_mf_mode: bool = False,
     report_em_mode: bool = True,
     pol_from_obs: bool = False,
+    no_model_error: bool = False,
 ) -> tuple[xr.Dataset, Optional[xr.Dataset]]:
     """Create formatted PARIS emissions and concentrations datasets.
 
@@ -235,7 +253,11 @@ def main(
         emissions dataset and concentrations dataset
     """
     inv_outs = get_inversion_outputs_with_samples(
-        species=species, output_file_path=output_file_path, n_files=n_files, pol_from_obs=pol_from_obs
+        species=species,
+        output_file_path=output_file_path,
+        n_files=n_files,
+        pol_from_obs=pol_from_obs,
+        no_model_error=no_model_error,
     )
 
     # make country and flux output
@@ -308,7 +330,7 @@ def main(
         )
 
         # add sitenames variable and remove nsite coordinate
-        concentrations = concentrations.assign(sitenames = ("nsite", concentrations.nsite.values.astype("|S3")))
+        concentrations = concentrations.assign(sitenames=("nsite", concentrations.nsite.values.astype("|S3")))
         concentrations["sitenames"].attrs["long_name"] = "identifier of site"
         del concentrations["nsite"]
 
@@ -331,7 +353,9 @@ if __name__ == "__main__":
         type=str,
         help="path to country file; e.g. '/group/acrg/chem/LPDM/countries/country_EUROPE.nc'",
     )
-    parser.add_argument("-p", "--avr-obs-period", type=str, help="averaging period for measurements used in inversion")
+    parser.add_argument(
+        "-p", "--avr-obs-period", type=str, help="averaging period for measurements used in inversion"
+    )
     parser.add_argument("-o", "--output-path", type=str, help="path to dir to write formatted outputs")
     parser.add_argument("-t", "--output-tag", type=str, help="tag to add to output file names")
     parser.add_argument("-n", "--n-files", type=int, help="number of files to process")
@@ -348,18 +372,23 @@ if __name__ == "__main__":
         help="if set, report mode for concentrations/mole fractions (by default, mean is reported).",
     )
     parser.add_argument(
-            "--em-mean",
-            action="store_true",
-            default=False,
-            help="if set, report mean for country and flux totals (by default, mode is reported).",
+        "--em-mean",
+        action="store_true",
+        default=False,
+        help="if set, report mean for country and flux totals (by default, mode is reported).",
     )
     parser.add_argument(
-            "--pol-obs",
-            action="store_true",
-            default=False,
-            help="if set, this means that pollution_events_from_obs=True was specified",
+        "--pol-obs",
+        action="store_true",
+        default=False,
+        help="if set, this means that pollution_events_from_obs=True was specified",
     )
-
+    parser.add_argument(
+        "--no-model-error",
+        action="store_true",
+        default=False,
+        help="if set, this means that no_model_error=True was specified",
+    )
 
     args = parser.parse_args()
 
@@ -372,7 +401,8 @@ if __name__ == "__main__":
         return_concentrations=(not args.no_conc),
         report_mf_mode=args.mode,
         report_em_mode=(not args.em_mean),
-        pol_from_obs=args.pol_obs
+        pol_from_obs=args.pol_obs,
+        no_model_error=args.no_model_error,
     )
 
     output_path = Path(args.output_path)

--- a/acrg/paris_formatting/make_paris_outputs.py
+++ b/acrg/paris_formatting/make_paris_outputs.py
@@ -138,7 +138,7 @@ def make_country_output(
 def make_flux_outputs(
     inv_outs: list[InversionOutput],
     time_point: Literal["start", "midpoint"] = "midpoint",
-    report_mode: bool = True,
+    report_mode: bool = False,
 ) -> xr.Dataset:
     """Make flux output dataset"""
 
@@ -235,7 +235,7 @@ def main(
     n_files: Optional[int] = None,
     return_concentrations: bool = True,
     report_mf_mode: bool = False,
-    report_em_mode: bool = True,
+    report_em_mode: bool = False,
     pol_from_obs: bool = False,
     no_model_error: bool = False,
     ndraw: int = 10000,
@@ -377,10 +377,10 @@ if __name__ == "__main__":
         help="if set, report mode for concentrations/mole fractions (by default, mean is reported).",
     )
     parser.add_argument(
-        "--em-mean",
+        "--em-mod",
         action="store_true",
         default=False,
-        help="if set, report mean for country and flux totals (by default, mode is reported).",
+        help="if set, report mode for country and flux totals (by default, mean is reported).",
     )
     parser.add_argument(
         "--pol-obs",
@@ -406,7 +406,7 @@ if __name__ == "__main__":
         n_files=args.n_files,
         return_concentrations=(not args.no_conc),
         report_mf_mode=args.mode,
-        report_em_mode=(not args.em_mean),
+        report_em_mode=args.em_mode,
         pol_from_obs=args.pol_obs,
         no_model_error=args.no_model_error,
         ndraw=args.ndraw,

--- a/acrg/paris_formatting/make_paris_outputs.py
+++ b/acrg/paris_formatting/make_paris_outputs.py
@@ -377,7 +377,7 @@ if __name__ == "__main__":
         help="if set, report mode for concentrations/mole fractions (by default, mean is reported).",
     )
     parser.add_argument(
-        "--em-mod",
+        "--em-mode",
         action="store_true",
         default=False,
         help="if set, report mode for country and flux totals (by default, mean is reported).",

--- a/acrg/paris_formatting/process_rhime_output.py
+++ b/acrg/paris_formatting/process_rhime_output.py
@@ -2,6 +2,7 @@
 Code to process RHIME outputs into format that is easier to
 manipulate.
 """
+
 from dataclasses import dataclass
 from typing import Any, cast, Optional, TypeVar, Union
 
@@ -142,7 +143,11 @@ class InversionOutput:
 
     @classmethod
     def from_rhime(
-        cls: type[InvOut], ds: xr.Dataset, pol_from_obs: bool, ndraw: Optional[int] = None
+        cls: type[InvOut],
+        ds: xr.Dataset,
+        pol_from_obs: bool,
+        no_model_error: bool = False,
+        ndraw: Optional[int] = None,
     ) -> InvOut:
         """Make InversionOutput object from RHIME output dataset."""
         flux = ds.fluxapriori
@@ -168,7 +173,9 @@ class InversionOutput:
             model_kwargs["bcprior"] = None
             model_kwargs["bcprior_dims"] = None
 
-        model = get_rhime_model(ds_clean, use_bc=use_bc, pol_from_obs=pol_from_obs, **model_kwargs)  # type: ignore
+        model = get_rhime_model(
+            ds_clean, use_bc=use_bc, pol_from_obs=pol_from_obs, no_model_error=no_model_error, **model_kwargs
+        )  # type: ignore
 
         if ndraw is not None:
             trace = make_idata_from_rhime_outs(ds_clean, ndraw=ndraw)
@@ -247,13 +254,15 @@ class InversionOutput:
             return result.unstack("nmeasure")
 
         return result
-    
+
     def get_obs_err(self, unstack_nmeasure: bool = True) -> xr.DataArray:
         """Return y observations errors.
 
         By default, `nmeasure` is converted to `site` and `time`.
         """
-        result = nmeasure_to_site_time_data_array(self.obs_err, self.site_indicators, self.site_names, self.times)
+        result = nmeasure_to_site_time_data_array(
+            self.obs_err, self.site_indicators, self.site_names, self.times
+        )
 
         if unstack_nmeasure:
             return result.unstack("nmeasure")

--- a/acrg/paris_formatting/sampling.py
+++ b/acrg/paris_formatting/sampling.py
@@ -121,6 +121,7 @@ def get_rhime_model(
     coord_dim: str = "nmeasure",
     use_bc: bool = True,
     pol_from_obs: bool = False,
+    no_model_error: bool = False,
 ) -> pm.Model:
     """Make RHIME model wih model error given by multiplicative scaling of pollution events
     plus constant minimum value.
@@ -137,6 +138,7 @@ def get_rhime_model(
         coord_dim: name of dimension used for coordinates of observations
         use_bc: if False, run without boundary conditions (e.g. if baseline subtracted from observations)
         pol_from_obs: if True, this means that pollution_events_from_obs=True was specified
+        no_model_error: if True, only use obs error in likelihood
 
     Returns:
         PyMC model for RHIME model with given priors and minimum model error.
@@ -182,11 +184,16 @@ def get_rhime_model(
                 rhime_outs_ds.sigmafreqindex.values.astype(int),
             ]
         )
-        epsilon = pm.Deterministic(
-            "epsilon",
-            pt.maximum(pt.sqrt(rhime_outs_ds.Yerror.values**2 + mult_error**2), min_model_error),
-            dims=coord_dim,
-        )
+        # set up obs + model error
+        if no_model_error is True:
+            epsilon = pm.Deterministic("epsilon", np.abs(rhime_outs_ds.Yerror.values), dims=coord_dim)
+        else:
+            epsilon = pm.Deterministic(
+                "epsilon",
+                pt.maximum(pt.sqrt(rhime_outs_ds.Yerror.values**2 + mult_error**2), min_model_error),  # type: ignore
+                dims=coord_dim,
+            )
+
         pm.Normal("y", mu, epsilon, dims=coord_dim, observed=rhime_outs_ds.Yobs)
 
     return model

--- a/acrg/paris_formatting/stats.py
+++ b/acrg/paris_formatting/stats.py
@@ -58,7 +58,7 @@ def calculate_stats(
     chunk_dim: str,
     chunk_size: int = 10,
     var_names: Optional[list[str]] = None,
-    report_mode: bool = True,
+    report_mode: bool = False,
     add_bc_suffix: bool = False,
 ) -> list[xr.Dataset]:
     output = []


### PR DESCRIPTION
**Description:**

Added command line options:
- `ndraw` for number of prior/predictive samples, default is 10,000
- `--no-model-error` which is a flag; if set, then it uses the model without model error (i.e. only obs error)
- `--em-mode` which is a flag; if set, then mode is used as central value instead of mean; the default is mean. (The `--em-mean` option has been removed)

Changed how the `output_tag` option is used, so the emissions file is just called `{output_tag}.nc` and the concentrations file is called `{output_tag}_concentrations.nc`. 