### PR TITLE
Added code to align basis functions to country

### DIFF
--- a/acrg/paris_formatting/array_ops.py
+++ b/acrg/paris_formatting/array_ops.py
@@ -157,3 +157,26 @@ def sparse_xr_dot(
     func = wrapper if debug else _func
 
     return xr.apply_ufunc(func, da1, da2, input_core_dims=input_core_dims, join="outer")
+
+
+def align_sparse_lat_lon(sparse_da: xr.DataArray, other_array: DataWithCoords) -> xr.DataArray:
+    """Align lat/lon coordinates of sparse_da with lat/lon coordinates from other_array.
+
+    NOTE: This is a work-around for an xarray Issue: https://github.com/pydata/xarray/issues/3445
+
+    Args:
+        sparse_da: xarray DataArray with sparse underlying array
+        other_array: xarray Dataset or DataArray whose lat/lon coordinates should be used
+            to replace the lat/lon coordinates in sparse_da
+
+    Returns:
+        copy of sparse_da with lat/lon coords from other_array
+    """
+    if len(sparse_da.lon) != len(other_array.lon):
+        raise ValueError("Both arrays must have the same number lon "
+                         f"coordinates: {len(sparse_da.lon)} != {len(other_array.lon)}")
+    if len(sparse_da.lat) != len(other_array.lat):
+        raise ValueError("Both arrays must have the same number lat "
+                         f"coordinates: {len(sparse_da.lat)} != {len(other_array.lat)}")
+
+    return sparse_da.assign_coords(lat=other_array.lat, lon=other_array.lon)

--- a/acrg/paris_formatting/countries.py
+++ b/acrg/paris_formatting/countries.py
@@ -9,7 +9,7 @@ import xarray as xr
 from openghg_inversions import convert, utils
 from xarray.core.common import DataWithCoords
 
-from array_ops import get_xr_dummies, sparse_xr_dot
+from array_ops import align_sparse_lat_lon, get_xr_dummies, sparse_xr_dot
 from process_rhime_output import InversionOutput
 
 # type for xr.Dataset *or* xr.DataArray
@@ -89,9 +89,12 @@ class Countries:
         Returns:
             xr.DataArray with coordinate dimensions ("country", "basis_region")
         """
+        # multiply flux and basis and align to country lat/lon
+        flux_x_basis = align_sparse_lat_lon(inv_out.flux * inv_out.basis, self.area_grid)
+
         # compute matrix/tensor product: country_mat.T @ (area_grid * flux * basis_mat)
         # transpose doesn't need to be taken explicitly because alignment is done by dimension name
-        result = sparse_xr_dot(self.matrix, self.area_grid * inv_out.flux * inv_out.basis)
+        result = sparse_xr_dot(self.matrix, self.area_grid * flux_x_basis)
 
         if sparse:
             return result

--- a/acrg/paris_formatting/countries.py
+++ b/acrg/paris_formatting/countries.py
@@ -89,9 +89,14 @@ class Countries:
         Returns:
             xr.DataArray with coordinate dimensions ("country", "basis_region")
         """
+        # align basis to the country lat/lon (inv_out.basis is aligned to "xsensitivity" in the RHIME outputs,
+        # which could have different lat/lon coordinates from inv_out.flux if the footprints and flux had differing
+        # lat/lon coordinates)
+        _, basis = xr.align(inv_out.basis, self.area_grid, join="override")
+
         # compute matrix/tensor product: country_mat.T @ (area_grid * flux * basis_mat)
         # transpose doesn't need to be taken explicitly because alignment is done by dimension name
-        result = sparse_xr_dot(self.matrix, self.area_grid * inv_out.flux * inv_out.basis)
+        result = sparse_xr_dot(self.matrix, self.area_grid * inv_out.flux * basis)
 
         if sparse:
             return result

--- a/acrg/paris_formatting/countries.py
+++ b/acrg/paris_formatting/countries.py
@@ -89,14 +89,9 @@ class Countries:
         Returns:
             xr.DataArray with coordinate dimensions ("country", "basis_region")
         """
-        # align basis to the country lat/lon (inv_out.basis is aligned to "xsensitivity" in the RHIME outputs,
-        # which could have different lat/lon coordinates from inv_out.flux if the footprints and flux had differing
-        # lat/lon coordinates)
-        _, basis = xr.align(inv_out.basis, self.area_grid, join="override")
-
         # compute matrix/tensor product: country_mat.T @ (area_grid * flux * basis_mat)
         # transpose doesn't need to be taken explicitly because alignment is done by dimension name
-        result = sparse_xr_dot(self.matrix, self.area_grid * inv_out.flux * basis)
+        result = sparse_xr_dot(self.matrix, self.area_grid * inv_out.flux * inv_out.basis)
 
         if sparse:
             return result

--- a/acrg/paris_formatting/process_rhime_output.py
+++ b/acrg/paris_formatting/process_rhime_output.py
@@ -155,14 +155,7 @@ class InversionOutput:
 
         ds_clean = clean_rhime_output(ds)
         site_indicators = ds_clean.siteindicator
-
-        # align basis to the country lat/lon (inv_out.basis is aligned to "xsensitivity" in the RHIME outputs,
-        # which could have different lat/lon coordinates from inv_out.flux if the footprints and flux had differing
-        # lat/lon coordinates)
-        _, ds_basis_aligned = xr.align(flux, ds_clean.basisfunctions, join="override")
-
-
-        basis = get_xr_dummies(ds_basis_aligned, cat_dim="nx", categories=ds_clean.nx.values)
+        basis = get_xr_dummies(ds_clean.basisfunctions, cat_dim="nx", categories=ds_clean.nx.values)
 
         model_kwargs = get_sampling_kwargs_from_rhime_outs(ds)
         model_kwargs = cast(dict[str, Any], model_kwargs)  # adding other types of values next...

--- a/acrg/paris_formatting/process_rhime_output.py
+++ b/acrg/paris_formatting/process_rhime_output.py
@@ -156,7 +156,13 @@ class InversionOutput:
         ds_clean = clean_rhime_output(ds)
         site_indicators = ds_clean.siteindicator
 
-        basis = get_xr_dummies(ds_clean.basisfunctions, cat_dim="nx", categories=ds_clean.nx.values)
+        # align basis to the country lat/lon (inv_out.basis is aligned to "xsensitivity" in the RHIME outputs,
+        # which could have different lat/lon coordinates from inv_out.flux if the footprints and flux had differing
+        # lat/lon coordinates)
+        _, ds_basis_aligned = xr.align(flux, ds_clean.basisfunctions, join="override")
+
+
+        basis = get_xr_dummies(ds_basis_aligned, cat_dim="nx", categories=ds_clean.nx.values)
 
         model_kwargs = get_sampling_kwargs_from_rhime_outs(ds)
         model_kwargs = cast(dict[str, Any], model_kwargs)  # adding other types of values next...


### PR DESCRIPTION
If the footprint and flux used in the inversion had differing lat/lon coordinates, then the basis functions will be aligned to the footprint (and "xsensitivity"), while the flux that is saved will not be aligned to the footprint.

This causes a problem in some cases when trying to compute country totals.

NOTE: we're using "override" because `inv_out.basis` is a sparse matrix and currently you can't forward fill in more than one dimension when using sparse matrices in xarray: https://github.com/pydata/xarray/issues/3445

*Pull Request Template: delete as needed and mark appropriate check boxes [ ] with an x*

**Description:**

*One or two line description of change. Reference any relevant issues or other PRs using #XX e.g. #123 (use "closes #XX" to close the issue)*

**Type of Change:**

[ ] Bug fix

[ ] New feature

[ ] Code-breaking change

**Checklist:**

[ ] Code documentation has been updated if needed

[ ] If new tests are needed, they have been added

[ ] All tests pass

[ ] No merge conflicts

[ ] /CHANGELOG.md has been updated if change is significant


**Other Comments:**

*Any additional comments to reviewers not accounted for above*
