### PR TITLE
Ignore "The..." when looking for country codes

### DIFF
--- a/acrg/paris_formatting/attribute_parsers.py
+++ b/acrg/paris_formatting/attribute_parsers.py
@@ -118,9 +118,9 @@ def get_country_code(
     if iso3166 is None:
         iso3166 = get_iso3166_codes()
 
-    # first try to match long names
+    # first try to match long names, ignoring "The " at the beginning of a name
     for v in iso3166.values():  # type: ignore
-        if x.lower() == v["iso_long_name"].lower():
+        if x.lower().lstrip("the ") == v["iso_long_name"].lower().lstrip("the "):
             return v[code]
 
     # next try to match unofficial names


### PR DESCRIPTION
Removing "The " from the beginning of ISO long names doesn't change the number of distinct countries, so this is done to try to match names from the East Asia county file correctly.

*Pull Request Template: delete as needed and mark appropriate check boxes [ ] with an x*

**Description:**

Closes issue #190 

**Type of Change:**

[ ] Bug fix

[ ] New feature

[ ] Code-breaking change

**Checklist:**

[ ] Code documentation has been updated if needed

[ ] If new tests are needed, they have been added

[ ] All tests pass

[ ] No merge conflicts

[ ] /CHANGELOG.md has been updated if change is significant


**Other Comments:**

*Any additional comments to reviewers not accounted for above*
