### PR TITLE
Fixed units for flat BC

### DIFF
--- a/acrg/BC/make_mean_baseline_obs_BC.py
+++ b/acrg/BC/make_mean_baseline_obs_BC.py
@@ -163,7 +163,12 @@ def create_flat_bc_prior(
     bc = bc_template * baseline_da * units
     bc.attrs["title"] = title
     bc.attrs["species"] = species
-    bc.attrs["units"] = f"{units} mol / mol"
+    bc.attrs["units"] = "mol / mol"
+
+    # add units to data vars
+    for dv in bc.data_vars:
+        bc[dv].attrs["units"] = "mol/mol"
+
     bc.attrs["author"] = author
     bc.attrs["date_created"] = str(np.datetime64("now"))
 


### PR DESCRIPTION
**Description:**

For flat BCs, the data was being converted to mol/mol, but the units were being set as the original units (e.g. ppb, ppt, etc).

I also added "mol/mol" units to each data variable, which will let us "quantify" the data using pint (so we can do unit-aware calculation).

**Type of Change:**

[x] Bug fix: closes #197

**Checklist:**

[ ] Code documentation has been updated if needed

[ ] If new tests are needed, they have been added

[ ] All tests pass

[ ] No merge conflicts

[ ] /CHANGELOG.md has been updated if change is significant


**Other Comments:**

*Any additional comments to reviewers not accounted for above*
