### PR TITLE
Update BC_CAMS.py to fix typo of lon_e --> lon_w

### DIFF
--- a/acrg/BC/BC_CAMS.py
+++ b/acrg/BC/BC_CAMS.py
@@ -558,7 +558,7 @@ def create_CAMS_BC(ds,
 
     lon_w = (np.abs(ds.coords[variables['lon']].values - min(fp_lon))).argmin()
     if ds.coords[variables['lon']].values[lon_w] > min(fp_lon) and lon_w != 0:
-        lon_e -= 1
+        lon_w -= 1
 
     #Cut to these and then interpolate
     north = ds.sel(latitude  = ds.coords[variables['lat']][lat_n],


### PR DESCRIPTION
**Description:**

Closes #198 . Seems to be a typo in the CAMS BC code where the `lon_e` value was being updated based on a check on `lon_w`. This PR corrects this.

**Type of Change:**

[x] Bug fix

**Checklist:**

[x] No merge conflicts

**Unfortunately not working:**
- All tests pass

**Not needed:**

- /CHANGELOG.md has been updated if change is significant
- Code documentation has been updated if needed
- If new tests are needed, they have been added
